### PR TITLE
Truncate column examples to save on session space

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # OHMSImport
 Upload a valid .zip file containing valid OHMS XML files into Omeka.
 
-# Omeka MySQL Change
-
-In order to accommodate OHMS XML files with lengthy transcripts, the following MySQL database change is necessary.
-
-In the 'omek_sessions' table, the field with Name 'data' should have Type set to 'mediumblob'.
-
 # Possible Issue
 
 Be sure to set background.php.path correctly in the Omeka application config.  This path will vary depending on your server setup.

--- a/models/OhmsImport/File.php
+++ b/models/OhmsImport/File.php
@@ -93,7 +93,10 @@ class OhmsImport_File implements IteratorAggregate
         $rowIterator = $this->getIterator();
         try {
             $this->_columnNames = $rowIterator->getColumnNames();
-            $this->_columnExamples = $rowIterator->current(); 
+            $this->_columnExamples = $rowIterator->current();
+            foreach ($this->_columnExamples as $key => $value) {
+                $this->_columnExamples[$key] = substr($value, 0, 30);
+            }
         } catch (OhmsImport_DuplicateColumnException $e) {
             $this->_parseErrors[] = $e->getMessage() 
                 . ' ' . __('Please ensure that all column names are unique.');


### PR DESCRIPTION
The plugin has historically told users to alter the Omeka session table definition to allow more storage. This is only necessary because the plugin stores the entire content of each "column" in the session before showing the mapping page. Only the first few characters are ever visible, so we can just truncate the column example texts before returning them and the length of the transcript will no longer matter.